### PR TITLE
Fix _getUTF8Length function

### DIFF
--- a/lib/qrcode.js
+++ b/lib/qrcode.js
@@ -268,7 +268,7 @@ function QRCode(options) {
   //Gets text length
   function _getUTF8Length(content) {
     var result = encodeURI(content).toString().replace(/\%[0-9a-fA-F]{2}/g, 'a');
-    return result.length + (result.length != content ? 3 : 0);
+    return result.length + (result.length != content.length ? 3 : 0);
   }
   
   //Generate QR Code matrix


### PR DESCRIPTION
There is missing ```length``` for ```content```.