### PR TITLE
Use `eval('require')` instead of `require` to avoid bundler error

### DIFF
--- a/lib/qrcode.js
+++ b/lib/qrcode.js
@@ -410,7 +410,7 @@ QRCode.prototype.save = function(file, callback) {
   }
   try {
     //Package 'fs' is available in node.js but not in a web browser
-    var fs = require('fs');
+    var fs = eval('require')('fs');
     fs.writeFile(file, data, callback);
   }
   catch (e) {


### PR DESCRIPTION
Use `eval('require')` instead of `require` to avoid bundler error.

This allow this package continue work with Node.js and can avoid a bundler error.

This PR fixes papnkukn/qrcode-svg#11