### PR TITLE
Remove inline style.

### DIFF
--- a/lib/qrcode.js
+++ b/lib/qrcode.js
@@ -311,10 +311,10 @@ QRCode.prototype.svg = function(opt) {
   
   //Populate with predefined shape instead of "rect" elements, thanks to @kkocdko
   var predefined = typeof options.predefined != "undefined" ? !!options.predefined : false;
-  var defs = predefined ? indent + '<defs><path id="qrmodule" d="M0 0 h' + ysize + ' v' + xsize + ' H0 z" style="fill:' + options.color + ';shape-rendering:crispEdges;" /></defs>' + EOL : '';
+  var defs = predefined ? indent + '<defs><path id="qrmodule" d="M0 0 h' + ysize + ' v' + xsize + ' H0 z" fill="' + options.color + '" shape-rendering="crispEdges"/></defs>' + EOL : '';
   
   //Background rectangle
-  var bgrect = indent + '<rect x="0" y="0" width="' + width + '" height="' + height + '" style="fill:' + options.background + ';shape-rendering:crispEdges;"/>' + EOL;
+  var bgrect = indent + '<rect x="0" y="0" width="' + width + '" height="' + height + '" fill="' + options.background + '" shape-rendering="crispEdges"/>' + EOL;
   
   //Rectangles representing modules
   var modrect = '';
@@ -353,14 +353,14 @@ QRCode.prototype.svg = function(opt) {
         }
         else {
           //Module as rectangle element
-          modrect += indent + '<rect x="' + px.toString() + '" y="' + py.toString() + '" width="' + xsize + '" height="' + ysize + '" style="fill:' + options.color + ';shape-rendering:crispEdges;"/>' + EOL;
+          modrect += indent + '<rect x="' + px.toString() + '" y="' + py.toString() + '" width="' + xsize + '" height="' + ysize + '" fill="' + options.color + '" shape-rendering="crispEdges"/>' + EOL;
         }
       }
     }
   }
   
   if (join) {
-    modrect = indent + '<path x="0" y="0" style="fill:' + options.color + ';shape-rendering:crispEdges;" d="' + pathdata + '" />';
+    modrect = indent + '<path x="0" y="0" fill="' + options.color + '" shape-rendering="crispEdges" d="' + pathdata + '" />';
   }
 
   var svg = "";


### PR DESCRIPTION
Closes #8.

`crispEdges` and `fill` can be expressed as attributes in SVG. By doing it this way CSP headers which ban inline style attributes won't be upset by the SVG.