### PR TITLE
UTF-8 encoding fix

### DIFF
--- a/lib/qrcode.js
+++ b/lib/qrcode.js
@@ -27,42 +27,29 @@
 //   http://www.denso-wave.com/qrcode/faqpatent-e.html
 //
 //---------------------------------------------------------------------
+
+// Thanks to @19z
+function toUTF8(text){
+  const code = encodeURIComponent(text);
+  let bytes = [];
+  for (let i = 0; i < code.length; i++) {
+    const c = code.charAt(i);
+    if (c === '%') {
+      const hex = code.charAt(i + 1) + code.charAt(i + 2);
+      const hexVal = parseInt(hex, 16);
+      bytes.push(hexVal);
+      i += 2;
+    } else {
+      bytes.push(c.charCodeAt(0));
+    }
+  }
+  return bytes;
+}
+
 function QR8bitByte(data) {
   this.mode = QRMode.MODE_8BIT_BYTE;
   this.data = data;
-  this.parsedData = [];
-
-  // Added to support UTF-8 Characters
-  for (var i = 0, l = this.data.length; i < l; i++) {
-    var byteArray = [];
-    var code = this.data.charCodeAt(i);
-
-    if (code > 0x10000) {
-      byteArray[0] = 0xF0 | ((code & 0x1C0000) >>> 18);
-      byteArray[1] = 0x80 | ((code & 0x3F000) >>> 12);
-      byteArray[2] = 0x80 | ((code & 0xFC0) >>> 6);
-      byteArray[3] = 0x80 | (code & 0x3F);
-    } else if (code > 0x800) {
-      byteArray[0] = 0xE0 | ((code & 0xF000) >>> 12);
-      byteArray[1] = 0x80 | ((code & 0xFC0) >>> 6);
-      byteArray[2] = 0x80 | (code & 0x3F);
-    } else if (code > 0x80) {
-      byteArray[0] = 0xC0 | ((code & 0x7C0) >>> 6);
-      byteArray[1] = 0x80 | (code & 0x3F);
-    } else {
-      byteArray[0] = code;
-    }
-
-    this.parsedData.push(byteArray);
-  }
-
-  this.parsedData = Array.prototype.concat.apply([], this.parsedData);
-
-  if (this.parsedData.length != this.data.length) {
-    this.parsedData.unshift(191);
-    this.parsedData.unshift(187);
-    this.parsedData.unshift(239);
-  }
+  this.parsedData = toUTF8(data);
 }
 
 QR8bitByte.prototype = {
@@ -267,8 +254,7 @@ function QRCode(options) {
 
   //Gets text length
   function _getUTF8Length(content) {
-    var result = encodeURI(content).toString().replace(/\%[0-9a-fA-F]{2}/g, 'a');
-    return result.length + (result.length != content ? 3 : 0);
+    return toUTF8(content).length;
   }
   
   //Generate QR Code matrix


### PR DESCRIPTION
Fixes #25. Some non-ASCII characters were getting encoded to a different value or causing a "code length overflow" error.

`var svg = new QRCode("🐱🐶").svg();`